### PR TITLE
Add timelining into moonlite

### DIFF
--- a/Moonlite/Types.lua
+++ b/Moonlite/Types.lua
@@ -61,10 +61,6 @@ export type MoonProperty = {
 export type MoonElement = {
 	Target: Instance?,
 
-	Locks: {
-		[any]: true,
-	},
-
 	Props: {
 		[string]: MoonProperty,
 	},

--- a/Moonlite/Types.lua
+++ b/Moonlite/Types.lua
@@ -70,6 +70,10 @@ export type MoonElement = {
 	},
 }
 
+export type MoonTarget = {
+	[Instance]: MoonElement,
+}
+
 export type MoonJointInfo = {
 	Name: string,
 	Joint: Motor6D,

--- a/Moonlite/Types.lua
+++ b/Moonlite/Types.lua
@@ -66,6 +66,22 @@ export type MoonElement = {
 	},
 }
 
+export type MoonProperties = {
+	[string]: any,
+}
+
+export type MoonFrameBuffer = {
+	[Instance]: {
+		[number]: MoonProperties,
+	},
+}
+
+export type MoonElementLocks = {
+	[Instance]: {
+		[string]: boolean,
+	},
+}
+
 export type MoonTarget = {
 	[Instance]: MoonElement,
 }
@@ -94,29 +110,30 @@ export type MoonAnimSave = {
 	Information: MoonAnimInfo,
 }
 
-export type MoonMarkers = {
-	[Instance]: {
-		[number]: {
-			StartMarkers: {
-				[string]: {
-					[string]: any,
-				},
-			},
-
-			EndMarkers: {
-				[string]: {
-					[string]: any,
-				},
-			},
-		},
+export type MoonMarkerData = {
+	StartMarkers: {
+		[string]: MoonProperties,
 	},
+	EndMarkers: {
+		[string]: MoonProperties,
+	},
+}
+
+export type MoonFrameMarkers = {
+	[number]: MoonMarkerData,
+}
+
+export type MoonMarkerSignals = {
+	[string]: BindableEvent,
+}
+
+export type MoonMarkers = {
+	[Instance]: MoonFrameMarkers,
 }
 
 export type ActiveMoonTracks<T> = {
 	[T]: {
-		[Instance]: {
-			[string]: any,
-		},
+		[Instance]: MoonProperties,
 	},
 }
 

--- a/Moonlite/Types.lua
+++ b/Moonlite/Types.lua
@@ -94,6 +94,24 @@ export type MoonAnimSave = {
 	Information: MoonAnimInfo,
 }
 
+export type MoonMarkers = {
+	[Instance]: {
+		[number]: {
+			StartMarkers: {
+				[string]: {
+					[string]: any,
+				},
+			},
+
+			EndMarkers: {
+				[string]: {
+					[string]: any,
+				},
+			},
+		},
+	},
+}
+
 export type ActiveMoonTracks<T> = {
 	[T]: {
 		[Instance]: {

--- a/Moonlite/Types.lua
+++ b/Moonlite/Types.lua
@@ -84,6 +84,7 @@ export type MoonAnimInfo = {
 	Created: number,
 	ExportedPriority: string,
 	Modified: number,
+	FPS: number?,
 	Length: number,
 	Looped: boolean,
 }
@@ -91,6 +92,14 @@ export type MoonAnimInfo = {
 export type MoonAnimSave = {
 	Items: { MoonAnimItem },
 	Information: MoonAnimInfo,
+}
+
+export type ActiveMoonTracks<T> = {
+	[T]: {
+		[Instance]: {
+			[string]: any,
+		},
+	},
 }
 
 export type Scratchpad = {

--- a/Moonlite/init.lua
+++ b/Moonlite/init.lua
@@ -34,9 +34,12 @@ type MoonAnimSave = Types.MoonAnimSave
 type MoonEaseInfo = Types.MoonEaseInfo
 type MoonKeyframe = Types.MoonKeyframe
 type MoonProperty = Types.MoonProperty
+type MoonElementLocks = Types.MoonElementLocks
 type MoonJointInfo = Types.MoonJointInfo
 type MoonKeyframePack = Types.MoonKeyframePack
 type MoonMarkers = Types.MoonMarkers
+type MoonMarkerSignals = Types.MoonMarkerSignals
+type MoonFrameBuffer = Types.MoonFrameBuffer
 type ActiveMoonTracks<T> = Types.ActiveMoonTracks<T>
 type GetSet<Inst, Value> = Types.GetSet<Inst, Value>
 
@@ -59,32 +62,15 @@ export type MoonTrack = typeof(setmetatable({} :: {
 	FrameRate: number,
 	TimePosition: number,
 
-	_tweens: { Tween },
 	_completed: BindableEvent,
 
-	_locks: {
-		[Instance]: {
-			[string]: boolean,
-		}
-	},
-
+	_locks: MoonElementLocks,
+	_buffer: MoonFrameBuffer,
 	_elements: { Instance },
 
 	_markers: MoonMarkers,
-	_markerSignals: {
-		[string]: BindableEvent
-	},
-	_endMarkerSignals: {
-		[string]: BindableEvent
-	},
-
-	_buffer: {
-		[Instance]: {
-			[number]: {
-				[string]: any	
-			},
-		}
-	},
+	_markerSignals: MoonMarkerSignals,
+	_endMarkerSignals: MoonMarkerSignals,
 
 	_root: Instance?,
 	_save: StringValue,

--- a/Moonlite/init.lua
+++ b/Moonlite/init.lua
@@ -435,7 +435,7 @@ local function compileItem(self: MoonTrack, item: MoonAnimItem, targets: MoonTar
 
 					targets[joint] = {
 						Props = props,
-						Instance = joint,
+						Target = joint,
 					}
 				end
 			end
@@ -467,22 +467,22 @@ local function getInterpolator<T>(value: T): (start: T, goal: T, delta: number) 
 	local valueType = typeof(value)
 
 	if typeof(valueType) == "ColorSequence" then
-		return function(start, goal, t: number)
+		return function(start: T, goal: T, t: number)
 			local value = lerp(start.Keypoints[1].Value, goal.Keypoints[1].Value, t)
 			return ColorSequence.new(value)
 		end
 	elseif typeof(valueType) == "NumberSequence" then
-		return function(start, goal, t: number)
+		return function(start: T, goal: T, t: number)
 			local value = lerp(start.Keypoints[1].Value, goal.Keypoints[1].Value, t)
 			return NumberSequence.new(value)
 		end
 	elseif typeof(valueType) == "NumberRange" then
-		return function(start, goal, t: number)
+		return function(start: T, goal: T, t: number)
 			local value = lerp(start.Min, goal.Min, t)
 			return NumberRange.new(value)
 		end
 	elseif CONSTANT_INTERPS[typeof(valueType)] then
-		return function(start, goal, t: number)
+		return function(start: T, goal: T, t: number)
 			if t >= 1 then
 				return goal
 			else

--- a/Moonlite/init.lua
+++ b/Moonlite/init.lua
@@ -36,12 +36,13 @@ type MoonKeyframe = Types.MoonKeyframe
 type MoonProperty = Types.MoonProperty
 type MoonJointInfo = Types.MoonJointInfo
 type MoonKeyframePack = Types.MoonKeyframePack
+type ActiveMoonTracks<T> = Types.ActiveMoonTracks<T>
 type GetSet<Inst, Value> = Types.GetSet<Inst, Value>
 
 local MoonTrack = {}
 MoonTrack.__index = MoonTrack
 
-local PlayingTracks = {}
+local PlayingTracks: ActiveMoonTracks<MoonTrack> = {}
 
 local CONSTANT_INTERPS = {
 	["Instance"] = true,
@@ -645,7 +646,7 @@ function Moonlite.CreatePlayer(save: StringValue, root: Instance?): MoonTrack
 
 		_scratch = {},
 		_root = root,
-	}, MoonTrack)
+	}, MoonTrack) :: MoonTrack
 
 	compileRouting(self)
 
@@ -672,7 +673,7 @@ function MoonTrack.GetElements(self: MoonTrack): { Instance }
 	return table.clone(self._elements)
 end
 
-function MoonTrack.LockElement(self: MoonTrack, inst: Instance?, lock: any?)
+function MoonTrack.LockElement(self: MoonTrack, inst: Instance, lock: any?)
 	if not self._locks[inst] then
 		self._locks[inst] = {}
 	end
@@ -684,7 +685,7 @@ function MoonTrack.LockElement(self: MoonTrack, inst: Instance?, lock: any?)
 	return true
 end
 
-function MoonTrack.UnlockElement(self: MoonTrack, inst: Instance?, lock: any?)
+function MoonTrack.UnlockElement(self: MoonTrack, inst: Instance, lock: any?)
 	local locks = self._locks[inst]
 
 	if locks then
@@ -698,7 +699,7 @@ function MoonTrack.UnlockElement(self: MoonTrack, inst: Instance?, lock: any?)
 	return true
 end
 
-function MoonTrack.IsElementLocked(self: MoonTrack, inst: Instance?): boolean
+function MoonTrack.IsElementLocked(self: MoonTrack, inst: Instance): boolean
 	return self._locks[inst] ~= nil
 end
 

--- a/Moonlite/init.lua
+++ b/Moonlite/init.lua
@@ -242,6 +242,26 @@ local function readValue(value: Instance)
 	end
 end
 
+local function getPropValue(self: MoonTrack, inst: Instance?, prop: string): (boolean, any?)
+	if inst then
+		local binding = Specials.Get(self._scratch, inst, prop)
+
+		if binding then
+			local get = binding.Get
+
+			if get then
+				return pcall(get, inst)
+			else
+				return true, binding.Default
+			end
+		end
+	end
+
+	return pcall(function()
+		return (inst :: any)[prop]
+	end)
+end
+
 local function setPropValue(self: MoonTrack, inst: Instance?, prop: string, value: any, isDefault: boolean?): boolean
 	if inst then
 		local binding = Specials.Get(self._scratch, inst, prop)
@@ -888,7 +908,10 @@ function MoonTrack.Play(self: MoonTrack)
 		props[instance] = defaults
 
 		for name in frames[0] do
-			defaults[name] = instance[name]
+			local success, value = getPropValue(self, instance, name)
+			if success then
+				defaults[name] = value
+			end
 		end
 	end
 

--- a/selene.toml
+++ b/selene.toml
@@ -1,0 +1,1 @@
+std = "roblox"


### PR DESCRIPTION
I've noticed two problems that arise from using tween chains - the first arises from being able to set the starting point and current position of the animation when syncing other clients mid-cutscene or when players joins. The second and more noticable issue is that the some animations have custom frame-rates and/or have custom animations that occur over a per frame basis which does not work with tweens as it'll make it choppy. 

This PR pre-buffers and fills frames that don't exist with the respective interpolated value and steps through the frames and applies the properties to the instance, which helps solves the previous issues, keeps instances in sync (for example: Camera CFrame), adds in seeking, and resetting back to the original state when the track ends

Edit: 
Also added in KeyframeEvents from Moon animator!