### PR TITLE
Updated moonlite to not interpolate certain static values

### DIFF
--- a/Moonlite/Specials.lua
+++ b/Moonlite/Specials.lua
@@ -34,6 +34,39 @@ local Specials = {} :: {
 	[string]: BindSet,
 }
 
+local StaticProperties = {
+	Camera = {
+		AttachToPart = true,
+		LookAtPart = true,
+	},
+
+	Humanoid = {
+		AddAccessory = true,
+		ChangeState = true,
+		EquipTool = true,
+		MoveTo = true,
+		Move = true,
+		PlayEmote = true,
+		RemoveAccessories = true,
+		TakeDamage = true,
+		UnequipTools = true,
+	},
+
+	ParticleEmitter = {
+		Emit = true,
+		Clear = true,
+	},
+
+	Sound = {
+		PlayOnce = true,
+		SetTime = true,
+		Play = true,
+		Resume = true,
+		Pause = true,
+		Stop = true,
+	},
+}
+
 local function getValue<T>(inst: Instance, name: string, default: T)
 	return inst:GetAttribute(`__moonlite_{name}`) or default
 end
@@ -472,6 +505,12 @@ Specials.Sound = {
 -- Module Export
 -------------------------------------------------------------------------------------------------------
 
+local staticBinds = {} :: {
+	[string]: {
+		[string]: boolean,
+	},
+}
+
 local classBinds = {} :: {
 	[string]: BindSet,
 }
@@ -543,8 +582,29 @@ local function get(work: Scratchpad, inst: Instance, prop: string): GetSet<any, 
 	return props[prop]
 end
 
+local function static(inst: Instance, prop: string): boolean
+	local className = inst.ClassName
+
+	if not staticBinds[className] then
+		local binds = {}
+
+		for class, propSet in StaticProperties do
+			if inst:IsA(class) then
+				for name, getSet in propSet do
+					binds[name] = getSet
+				end
+			end
+		end
+
+		staticBinds[className] = binds
+	end
+
+	return staticBinds[className][prop] == true
+end
+
 return {
 	Get = get,
+	Static = static,
 	Index = Specials,
 }
 

--- a/Moonlite/init.lua
+++ b/Moonlite/init.lua
@@ -616,16 +616,16 @@ local function compileFrames(self: MoonTrack, targets: MoonTarget)
 				end
 
 				if not value.Static then
-				local easeFunc = EaseFuncs.Get(lastEase)
+					local easeFunc = EaseFuncs.Get(lastEase)
 
-				for i = 0, delta do
-					local frameDelta = easeFunc(i / delta)
-					local frame = lastFrame + i
-					if not frames[frame] then
-						frames[frame] = {}
-					end
+					for i = 0, delta do
+						local frameDelta = easeFunc(i / delta)
+						local frame = lastFrame + i
+						if not frames[frame] then
+							frames[frame] = {}
+						end
 
-					frames[frame][name] = interpolate(lastValue, v.Value, frameDelta)
+						frames[frame][name] = interpolate(lastValue, v.Value, frameDelta)
 					end
 				end
 
@@ -673,7 +673,7 @@ local function restoreTrack(self: MoonTrack)
 
 	for instance, props in defaults do
 		for name, value in props do
-			(instance :: any)[name] = value
+			setPropValue(self, instance, name, value)
 		end
 	end
 

--- a/Moonlite/init.lua
+++ b/Moonlite/init.lua
@@ -454,7 +454,7 @@ local function compileItem(self: MoonTrack, item: MoonAnimItem, targets: MoonTar
 					local props: any = {
 						Transform = {
 							Default = CFrame.identity,
-
+							Static = false,
 							Sequence = unpackKeyframes(keyframes, function(c1: CFrame)
 								return c1:Inverse() * default
 							end),
@@ -477,13 +477,15 @@ local function compileItem(self: MoonTrack, item: MoonAnimItem, targets: MoonTar
 			end
 
 			local default: any = prop:FindFirstChild("default")
+			local name = prop.Name
 
 			if default then
 				default = readValue(default)
 			end
 
-			props[prop.Name] = {
+			props[name] = {
 				Default = default,
+				Static = Specials.Static(target, name),
 				Sequence = unpackKeyframes(prop),
 			}
 		end
@@ -613,6 +615,7 @@ local function compileFrames(self: MoonTrack, targets: MoonTarget)
 					continue
 				end
 
+				if not value.Static then
 				local easeFunc = EaseFuncs.Get(lastEase)
 
 				for i = 0, delta do
@@ -623,6 +626,7 @@ local function compileFrames(self: MoonTrack, targets: MoonTarget)
 					end
 
 					frames[frame][name] = interpolate(lastValue, v.Value, frameDelta)
+					end
 				end
 
 				lastEase = v.Ease
@@ -630,7 +634,7 @@ local function compileFrames(self: MoonTrack, targets: MoonTarget)
 				lastFrame = v.Time
 			end
 
-			if lastFrame < self.Frames then
+			if not value.Static and lastFrame < self.Frames then
 				local cache = frames[lastFrame][name]
 
 				for i = lastFrame, self.FrameRate do


### PR DESCRIPTION
This PR aims to fix an issue with restoring the track back to its default properties, alongside having certain properties of classes be "static" and not interpolate between those values. For example: emitting particles should only occur once at a frame, not interpolate from 0 -> 20 particles.