### PR TITLE
Update Specials.lua and Types.lua

### DIFF
--- a/Moonlite/Specials.lua
+++ b/Moonlite/Specials.lua
@@ -588,7 +588,7 @@ local function static(inst: Instance, prop: string): boolean
 	if not staticBinds[className] then
 		local binds = {}
 
-		for class, propSet in StaticProperties do
+		for class, propSet in pairs(StaticProperties) do
 			if inst:IsA(class) then
 				for name, getSet in propSet do
 					binds[name] = getSet

--- a/Moonlite/Types.lua
+++ b/Moonlite/Types.lua
@@ -56,6 +56,7 @@ export type MoonKeyframe = {
 export type MoonProperty = {
 	Default: any,
 	Sequence: { MoonKeyframe },
+	Static: boolean,
 }
 
 export type MoonElement = {


### PR DESCRIPTION
Fix "cannot iterate over table without indexer" in Luau
&
Fix Moonlite.lua Line 618 "Key 'Static' not found in table 'MoonProperty'"
