### PR TITLE
Fix error when trying to interpolate a string

### DIFF
--- a/Moonlite/init.lua
+++ b/Moonlite/init.lua
@@ -48,6 +48,7 @@ MoonTrack.__index = MoonTrack
 local CONSTANT_INTERPS = {
 	["Instance"] = true,
 	["boolean"] = true,
+	["string"] = true,
 	["nil"] = true,
 }
 


### PR DESCRIPTION
When trying to interpolate a string it errors out, constantly interpolating it fixes the issue.