### PR TITLE
Fix Rig ItemType property animations

### DIFF
--- a/Moonlite/init.lua
+++ b/Moonlite/init.lua
@@ -470,33 +470,33 @@ local function compileItem(self: MoonTrack, item: MoonAnimItem, targets: MoonTar
 				end
 			end
 		end
-	else
-		local props = {}
+	end
 
-		for i, prop in frame:GetChildren() do
-			if not prop:IsA("Folder") or prop == markerTrack then
-				continue
-			end
+	local props = {}
 
-			local default: any = prop:FindFirstChild("default")
-			local name = prop.Name
-
-			if default then
-				default = readValue(default)
-			end
-
-			props[name] = {
-				Default = default,
-				Static = Specials.Static(target, name),
-				Sequence = unpackKeyframes(prop),
-			}
+	for i, prop in frame:GetChildren() do
+		if not prop:IsA("Folder") or prop == markerTrack or prop.Name == "Rig" then
+			continue
 		end
 
-		targets[target] = {
-			Props = props,
-			Target = target,
+		local default: any = prop:FindFirstChild("default")
+		local name = prop.Name
+
+		if default then
+			default = readValue(default)
+		end
+
+		props[name] = {
+			Default = default,
+			Static = Specials.Static(target, name),
+			Sequence = unpackKeyframes(prop),
 		}
 	end
+
+	targets[target] = {
+		Props = props,
+		Target = target,
+	}
 
 	if markerTrack then
 		local markers = {}


### PR DESCRIPTION
Fixes issue 7 on Moonlite's main repository, allowing for Rig ItemTypes to have any other property (CFrame in my use case example) become animated instead of being skipped.

Instead of an "else" being used to separate the Rig ItemType setup vs. any other ItemType setup, I removed the "else" and ended the stack for the Rig setup, allowing the rest of the Model to get the benefit of animating any other property, in which the Rig ItemType setup did not include from its logic.

The rest of the ItemType setup makes sure that any other "Rig" property isn't animated, as it's assumed it would have been set up by the Rig ItemType.