### PR TITLE
Extended To Allow "Nil" As Default Values + Added Missing Camera Deactavation Logic For The AttachToPart Property.

### DIFF
--- a/Moonlite/Specials.lua
+++ b/Moonlite/Specials.lua
@@ -159,6 +159,10 @@ Specials.Camera = {
 				setCameraActive(work, camera, true)
 			else
 				work._cameraAttachToPart = nil
+
+				if not work._cameraLookAtPart then
+					setCameraActive(work, camera, false)
+				end
 			end
 		end,
 	}),

--- a/Moonlite/Types.lua
+++ b/Moonlite/Types.lua
@@ -68,7 +68,7 @@ export type MoonElement = {
 }
 
 export type MoonProperties = {
-	[string]: any,
+	[string]: { Value: any },
 }
 
 export type MoonFrameBuffer = {

--- a/Moonlite/Types.lua
+++ b/Moonlite/Types.lua
@@ -68,6 +68,10 @@ export type MoonElement = {
 }
 
 export type MoonProperties = {
+	[string]: any,
+}
+
+export type MoonPropertiesNil = {
 	[string]: { Value: any },
 }
 

--- a/Moonlite/init.lua
+++ b/Moonlite/init.lua
@@ -36,6 +36,7 @@ type MoonKeyframe = Types.MoonKeyframe
 type MoonProperty = Types.MoonProperty
 type MoonJointInfo = Types.MoonJointInfo
 type MoonProperties = Types.MoonProperties
+type MoonPropertiesNil = Types.MoonPropertiesNil
 type MoonFrameBuffer = Types.MoonFrameBuffer
 type MoonElementLocks = Types.MoonElementLocks
 type MoonKeyframePack = Types.MoonKeyframePack
@@ -80,7 +81,7 @@ export type MoonTrack = typeof(setmetatable({} :: {
 
 local PlayingTracks = {} :: {
 	[MoonTrack]: {
-		[Instance]: MoonProperties,
+		[Instance]: MoonPropertiesNil,
 	},
 }
 

--- a/Moonlite/init.lua
+++ b/Moonlite/init.lua
@@ -675,8 +675,8 @@ local function restoreTrack(self: MoonTrack)
 
 	if self.RestoreDefaults then
 		for instance, props in defaults do
-			for name, value in props do
-				setPropValue(self, instance, name, value)
+			for name, valueTbl in props do
+				setPropValue(self, instance, name, valueTbl.Value)
 			end
 		end
 	end
@@ -925,7 +925,7 @@ function MoonTrack.Play(self: MoonTrack)
 		for name in frames[0] do
 			local success, value = getPropValue(self, instance, name)
 			if success then
-				defaults[name] = value
+				defaults[name] = { Value = value }
 			end
 		end
 	end


### PR DESCRIPTION
Extended MoonProperties To Allow "Nil" To Be Set As A Default Value + Added Missing Camera Deactavation Logic For The "AttachToPart" Property.

Nil Issue:
If an animation property is nil before the animation plays, this value won't be tracked correctly since "Defaults[property] = nil" won't be picked up when restoring properties to default.

AttachToPart Issue:
Unlike the "LookAtPart" specials prop handler, when AttachToPart is set nil, the camera wasn't being deactivated; leading to the camera being stuck after an animation is stopped.