### PR TITLE
Added cleanup on setting to default value. Closes #23

### DIFF
--- a/Moonlite/Specials.lua
+++ b/Moonlite/Specials.lua
@@ -149,15 +149,16 @@ end
 Specials.Camera = {
 	AttachToPart = BoundProp({
 		Get = function(camera: Camera, work: Scratchpad)
-			return work._cameraAttachToPart
+			return work._cameraAttachToPart and work._cameraAttachToPart or {}
 		end,
 
 		Set = function(part: BasePart?, camera: Camera, work: Scratchpad)
-			if part then
+			if part and typeof(part) ~= "table"  then
 				work._activeCamera = camera
 				work._cameraAttachToPart = part
 				setCameraActive(work, camera, true)
 			else
+				setCameraActive(work, camera, false)
 				work._cameraAttachToPart = nil
 			end
 		end,


### PR DESCRIPTION
My attempt at fixing this. There's probably something I'm doing wrong here, but my solution is simply to have a default value of {} that way when the animation ends it will set the attached part to {} causing the render step connection to end.